### PR TITLE
Add centralized CLA workflow

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -1,0 +1,43 @@
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types:
+      - created
+  pull_request_target:
+    types:
+      - opened
+      - closed
+      - synchronize
+  workflow_call:
+
+jobs:
+  CLAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA
+        if: >
+          (github.event.comment.body == 'recheck'
+            || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')
+            || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.2.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
+        with:
+          path-to-signatures: ${{ env.GITHUB_REPOSITORY }}/cla.json
+          path-to-document: https://github.com/${{ env.GITHUB_REPOSITORY_OWNER }}/.github/blob/main/CLA.md
+          branch: cla-signatures
+          allowlist: github-actions[bot],dependabot-preview[bot],insights-engineering-bot
+          create-file-commit-message: '🛠 Init CLA Signatures'
+          remote-organization-name: ${{ env.GITHUB_REPOSITORY_OWNER }}
+          remote-repository-name: .github-private
+          signed-commit-message: '✍️ CLA signed by $contributorName in ${{ env.GITHUB_REPOSITORY }} in PR #$pullRequestNo'
+          custom-allsigned-prcomment: '✅ All contributors have signed the CLA'
+          custom-notsigned-prcomment: >-
+            <br/>
+            🎉 Thank you for your contribution! Before this PR can be accepted, we require that $you read and agree to our [Contributor License Agreement](${input.getPathToDocument()}).
+            <br/>
+            You can digitally sign the CLA by posting a comment on this Pull Request in the format shown below. This agreement will apply to this PR _as well as_ all future contributions on this repository.
+            <br/>
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'


### PR DESCRIPTION
This will be used by repositories in the organization as a separate workflow, where the workflow would look something like this:

```yaml
# CLA
name: CLA 🔏

on:
  issue_comment:
    types:
      - created
  pull_request_target:
    types:
      - opened
      - closed
      - synchronize

jobs:
  CLA:
    name: CLA 📝
    uses: insightsengineering/.github/.github/workflows/cla.yaml@main
```

This can be merged after https://github.com/insightsengineering/.github/pull/1
